### PR TITLE
✨	: 로그인 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,8 +30,15 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
+	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// JWT 관련 의존성
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/finalproject/tmeroom/TMeRoomApplication.java
+++ b/src/main/java/org/finalproject/tmeroom/TMeRoomApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class TMeRoomApplication {
 

--- a/src/main/java/org/finalproject/tmeroom/auth/config/SecurityConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/SecurityConfig.java
@@ -1,0 +1,51 @@
+package org.finalproject.tmeroom.auth.config;
+
+import lombok.RequiredArgsConstructor;
+import org.finalproject.tmeroom.auth.config.jwt.JwtAuthenticationFilter;
+import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // REST API는 CSRF 대응 필요 없음
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // CORS 기본 설정 적용
+                .cors(Customizer.withDefaults())
+
+                // 세션 관리 비활성화
+                .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+                // URI 인증, 인가 설정
+                .authorizeHttpRequests(auth -> auth
+                        .anyRequest().permitAll())
+
+                // JWT 인증필터 등록
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,43 @@
+package org.finalproject.tmeroom.auth.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            // 토큰 추출
+            String token = jwtTokenProvider.resolveToken(request, TokenType.ACCESS);
+
+            // 토큰 유효성 체크
+            if (token == null || !jwtTokenProvider.isTokenValid(token)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+            // Authentication 부여
+            UsernamePasswordAuthenticationToken authentication = jwtTokenProvider.getAuthentication(token);
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        } catch (RuntimeException e) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
@@ -27,7 +27,7 @@ public class JwtTokenProvider {
     private final TokenAuthenticationService tokenAuthenticationService;
 
     private final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * 60 * 60;
-    @Value("${jwt.secret-key}")
+    @Value("${jwt.secret.key}")
     private String JWT_SECRET_KEY;
     private byte[] KEY_BYTES;
 

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
@@ -3,10 +3,13 @@ package org.finalproject.tmeroom.auth.config.jwt;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
@@ -47,6 +50,45 @@ public class JwtTokenProvider {
                 .setExpiration(new Date(now.getTime() + tokenType.getValidTimeMilli()))
                 .signWith(getKey(), SignatureAlgorithm.HS256)
                 .compact();
-        return jwt;
     }
+
+    private Cookie findCookieByName(String name, HttpServletRequest request) {
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> cookie.getName().equals(name))
+                .findFirst()
+                .orElse(new Cookie(name, null));
+    }
+
+    public String resolveToken(HttpServletRequest request, TokenType tokenType) {
+        Cookie foundCookie = findCookieByName(tokenType.getName(), request);
+        return foundCookie.getValue();
+    }
+
+    public boolean isTokenValid(String token) {
+        try {
+            Jws<Claims> claims = Jwts
+                    .parserBuilder()
+                    .setSigningKey(getKey())
+                    .build()
+                    .parseClaimsJws(token);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public String getSubject(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public UsernamePasswordAuthenticationToken getAuthentication(String token) {
+        MemberDto memberDto = tokenAuthenticationService.getMemberDto(getSubject(token));
+        return new UsernamePasswordAuthenticationToken(memberDto, null, memberDto.getAuthorities());
+    }
+
 }

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
@@ -1,0 +1,54 @@
+package org.finalproject.tmeroom.auth.config.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+
+/**
+ * 작성자: 김태민
+ * 작성일자: 2023-09-13
+ * JWT를 발급하고, 검증하는 로직을 담은 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private final TokenAuthenticationService tokenAuthenticationService;
+
+    private final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * 60 * 60;
+    @Value("${jwt.secret-key}")
+    private String JWT_SECRET_KEY;
+    private byte[] KEY_BYTES;
+
+    @PostConstruct
+    private void init() {
+        KEY_BYTES = JWT_SECRET_KEY.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private Key getKey() {
+        return Keys.hmacShaKeyFor(KEY_BYTES);
+    }
+
+    public String createAccessToken(String subject) {
+        Claims claims = Jwts.claims().setSubject(subject);
+        Date now = new Date();
+        String jwt = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_MILLISECOND))
+                .signWith(getKey(), SignatureAlgorithm.HS256)
+                .compact();
+        return jwt;
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
@@ -1,8 +1,6 @@
 package org.finalproject.tmeroom.auth.config.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
@@ -13,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
+import java.util.Arrays;
 import java.util.Date;
 
 /**
@@ -26,7 +25,6 @@ public class JwtTokenProvider {
 
     private final TokenAuthenticationService tokenAuthenticationService;
 
-    private final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * 60 * 60;
     @Value("${jwt.secret.key}")
     private String JWT_SECRET_KEY;
     private byte[] KEY_BYTES;
@@ -40,13 +38,13 @@ public class JwtTokenProvider {
         return Keys.hmacShaKeyFor(KEY_BYTES);
     }
 
-    public String createAccessToken(String subject) {
+    public String createToken(String subject, TokenType tokenType) {
         Claims claims = Jwts.claims().setSubject(subject);
         Date now = new Date();
-        String jwt = Jwts.builder()
+        return Jwts.builder()
                 .setClaims(claims)
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALID_MILLISECOND))
+                .setExpiration(new Date(now.getTime() + tokenType.getValidTimeMilli()))
                 .signWith(getKey(), SignatureAlgorithm.HS256)
                 .compact();
         return jwt;

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/TokenType.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/TokenType.java
@@ -9,7 +9,7 @@ import org.springframework.http.ResponseCookie;
 public enum TokenType {
 
     ACCESS("accessToken", 1000L * 60 * 60),
-    REFRESH("accessToken", 1000L * 60 * 60 * 24 * 7),
+    REFRESH("refreshToken", 1000L * 60 * 60 * 24 * 7),
     ;
 
     private final String name;

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/TokenType.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/TokenType.java
@@ -1,0 +1,30 @@
+package org.finalproject.tmeroom.auth.config.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.ResponseCookie;
+
+@Getter
+@AllArgsConstructor
+public enum TokenType {
+
+    ACCESS("accessToken", 1000L * 60 * 60),
+    REFRESH("accessToken", 1000L * 60 * 60 * 24 * 7),
+    ;
+
+    private final String name;
+    private final long validTimeMilli;
+
+    private long getValidTimeSec() {
+        return validTimeMilli / 1000;
+    }
+
+    public ResponseCookie createHttpOnlyCookieFrom(String token) {
+        return ResponseCookie.from(getName(), token)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(getValidTimeSec())
+                .build();
+    }
+
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/controller/AuthController.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/controller/AuthController.java
@@ -1,0 +1,38 @@
+package org.finalproject.tmeroom.auth.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.finalproject.tmeroom.auth.config.jwt.TokenType;
+import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
+import org.finalproject.tmeroom.auth.data.dto.response.LoginResponseDto;
+import org.finalproject.tmeroom.auth.service.AuthService;
+import org.finalproject.tmeroom.common.data.dto.Response;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/login")
+    public Response<Void> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+
+        LoginResponseDto responseDto = authService.login(requestDto);
+
+        addTokenCookie(response, responseDto.getAccessToken(), TokenType.ACCESS);
+
+        return Response.success();
+    }
+
+    private void addTokenCookie(HttpServletResponse response, String token, TokenType tokenType) {
+        ResponseCookie tokenCookie = tokenType.createHttpOnlyCookieFrom(token);
+        response.addHeader(HttpHeaders.SET_COOKIE, tokenCookie.toString());
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
@@ -1,0 +1,12 @@
+package org.finalproject.tmeroom.auth.data.dto.request;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginRequestDto {
+
+    private String id;
+    private String pw;
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/data/dto/response/LoginResponseDto.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/data/dto/response/LoginResponseDto.java
@@ -1,0 +1,11 @@
+package org.finalproject.tmeroom.auth.data.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class LoginResponseDto {
+
+    private String accessToken;
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/service/AuthService.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/service/AuthService.java
@@ -1,0 +1,60 @@
+package org.finalproject.tmeroom.auth.service;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
+import org.finalproject.tmeroom.auth.config.jwt.TokenType;
+import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
+import org.finalproject.tmeroom.auth.data.dto.response.LoginResponseDto;
+import org.finalproject.tmeroom.common.exception.ApplicationException;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.finalproject.tmeroom.member.constant.MemberRole;
+import org.finalproject.tmeroom.member.data.entity.Member;
+import org.finalproject.tmeroom.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    //TODO: 테스트용, 삭제 필요
+    @PostConstruct
+    public void createTester() {
+        memberRepository.save(
+                Member.builder()
+                        .id("tester00")
+                        .pw(passwordEncoder.encode("test"))
+                        .nickname("tester")
+                        .email("tester@test.com")
+                        .role(MemberRole.USER)
+                        .build()
+        );
+    }
+
+    @Transactional
+    public LoginResponseDto login(LoginRequestDto requestDto) {
+
+        Member member = memberRepository.findById(requestDto.getId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        if (!passwordEncoder.matches(requestDto.getPw(), member.getPw())) {
+            throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        String accessToken = jwtTokenProvider.createToken(member.getId(), TokenType.ACCESS);
+        return LoginResponseDto.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+
+
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/service/TokenAuthenticationService.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/service/TokenAuthenticationService.java
@@ -19,8 +19,8 @@ public class TokenAuthenticationService {
 
     private final MemberRepository memberRepository;
 
-    public MemberDto findMemberBySubject(String subject) {
-        Member member = memberRepository.findById(subject)
+    public MemberDto getMemberDto(String memberId) {
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
         return MemberDto.from(member);

--- a/src/main/java/org/finalproject/tmeroom/auth/service/TokenAuthenticationService.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/service/TokenAuthenticationService.java
@@ -1,0 +1,28 @@
+package org.finalproject.tmeroom.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import org.finalproject.tmeroom.common.exception.ApplicationException;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
+import org.finalproject.tmeroom.member.data.entity.Member;
+import org.finalproject.tmeroom.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+
+/**
+ * 작성자: 김태민
+ * 작성일자: 2023-09-13
+ * JWT의 Subject로 회원 정보를 찾아 주는 서비스 로직
+ */
+@Service
+@RequiredArgsConstructor
+public class TokenAuthenticationService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberDto findMemberBySubject(String subject) {
+        Member member = memberRepository.findById(subject)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        return MemberDto.from(member);
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/common/config/JpaConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/common/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package org.finalproject.tmeroom.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+
+}

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
     INVALID_PERMISSION(HttpStatus.FORBIDDEN, "소유자 불일치"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
-    INVALID_PASSWORD(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
 //    ==== 여기까지 작성 ====
     ;
 

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -15,7 +15,9 @@ public enum ErrorCode {
     //    ==== 여기서부터 작성 ====
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
     INVALID_PERMISSION(HttpStatus.FORBIDDEN, "소유자 불일치"),
-    //    ==== 여기까지 작성 ====
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
+    INVALID_PASSWORD(HttpStatus.NOT_FOUND, "비밀번호가 일치하지 않습니다."),
+//    ==== 여기까지 작성 ====
     ;
 
     private final HttpStatus status;

--- a/src/main/java/org/finalproject/tmeroom/member/constant/MemberRole.java
+++ b/src/main/java/org/finalproject/tmeroom/member/constant/MemberRole.java
@@ -1,0 +1,14 @@
+package org.finalproject.tmeroom.member.constant;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum MemberRole {
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+    GUEST("ROLE_GUEST");
+
+    private final String name;
+}

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/MemberDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/MemberDto.java
@@ -1,10 +1,52 @@
 package org.finalproject.tmeroom.member.data.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+import org.finalproject.tmeroom.member.constant.MemberRole;
+import org.finalproject.tmeroom.member.data.entity.Member;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 @Getter
-@AllArgsConstructor
+@Setter
+@ToString(onlyExplicitlyIncluded = true)
 public class MemberDto {
-    String id;
+
+    @ToString.Include
+    private String id;
+    private String pw;
+    @ToString.Include
+    private String nickname;
+    @ToString.Include
+    private String email;
+    @ToString.Include
+    private MemberRole role;
+
+    @Builder
+    private MemberDto(String id, String nickname, String pw, String email, MemberRole role) {
+        this.id = id;
+        this.pw = pw;
+        this.nickname = nickname;
+        this.email = email;
+        this.role = role;
+    }
+
+    public static MemberDto from(Member member) {
+        return MemberDto.builder()
+                .id(member.getId())
+                .nickname(member.getNickname())
+                .email(member.getEmail())
+                .pw(member.getPw())
+                .build();
+    }
+
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add((GrantedAuthority) () -> role.getName());
+        return authorities;
+    }
 }

--- a/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.common.data.entity.BaseTimeEntity;
+import org.finalproject.tmeroom.member.constant.MemberRole;
 
 /**
  * 작성자: 김종민
@@ -39,6 +40,6 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     @NotNull
-    private String role;
+    private MemberRole role;
 
 }

--- a/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
@@ -6,10 +6,10 @@ import jakarta.persistence.Id;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import org.finalproject.tmeroom.common.data.entity.BaseTimeEntity;
 import org.finalproject.tmeroom.member.constant.MemberRole;
 
@@ -20,9 +20,7 @@ import org.finalproject.tmeroom.member.constant.MemberRole;
  */
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseTimeEntity {
     @Id
     @NotNull

--- a/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
@@ -42,4 +42,13 @@ public class Member extends BaseTimeEntity {
     @NotNull
     private MemberRole role;
 
+    @Builder
+    public Member(String id, String pw, String nickname, String email, MemberRole role) {
+        this.id = id;
+        this.pw = pw;
+        this.nickname = nickname;
+        this.email = email;
+        this.role = role == null ? MemberRole.GUEST : role;
+    }
+
 }

--- a/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
@@ -1,17 +1,30 @@
 package org.finalproject.TMeRoom.auth.config.jwt;
 
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.aspectj.lang.annotation.Before;
 import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
 import org.finalproject.tmeroom.auth.config.jwt.TokenType;
 import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
+import org.finalproject.tmeroom.member.constant.MemberRole;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.Date;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.BDDMockito.given;
 
 
 @SpringBootTest(classes = {JwtTokenProvider.class})
@@ -24,9 +37,13 @@ class JwtTokenProviderTest {
 
     @MockBean
     private TokenAuthenticationService tokenAuthenticationService;
+    @MockBean
+    private HttpServletRequest request;
+
+    private final String masterToken = "eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJhY2Nlc3NUb2tlbiIsInN1YiI6InRlc3RlciIsImlhdCI6MTY5NDc2MTE3NSwiZXhwIjo5MjIzMzcyMDM2ODU0Nzc1fQ.SUaqRU7eASLiN1Rw2AM5dJqd2a8hxpgTHLBxzzJ15MI";
 
     @Nested
-    @DisplayName("액세스 토큰 발급 기능 테스트")
+    @DisplayName("토큰 발급 기능 테스트")
     class aboutCreatingAccessToken {
 
         @Test
@@ -40,24 +57,97 @@ class JwtTokenProviderTest {
 
             // then
             assertThat(accessToken).isNotNull();
+            System.out.println(accessToken);
         }
     }
 
     @Nested
-    @DisplayName("액세스 토큰 발급 기능 테스트")
-    class aboutCreatingAccessToken {
+    @DisplayName("토큰 추출 기능 테스트")
+    class aboutResolvingToken {
 
         @Test
-        @DisplayName("액세스 토큰 발급시, 서브젝트를 넘기면, 액세스 토큰을 발급한다.")
-        void givenSubject_whenCreatingAccessToken_thenReturnsAccessToken() {
+        @DisplayName("액세스 토큰 추출시, 올바른 요청이라면, 추출된 액세스 토큰을 반환한다.")
+        void givenProperRequest_whenResolvingAccessToken_thenReturnsResolvedAccessToken() {
             // given
-            String subject = "tester";
+            String expectedToken = "ACCESS_TOKEN_STRING";
+            Cookie accessTokenCookie = createCookie("accessToken", expectedToken);
+            Cookie[] cookies = new Cookie[]{accessTokenCookie};
+            given(request.getCookies()).willReturn(cookies);
 
             // when
-            String accessToken = jwtTokenProvider.createToken(subject, TokenType.ACCESS);
+            String accessToken = jwtTokenProvider.resolveToken(request, TokenType.ACCESS);
 
             // then
-            assertThat(accessToken).isNotNull();
+            assertThat(accessToken).isEqualTo(expectedToken);
         }
+
+        @Test
+        @DisplayName("액세스 토큰 추출시, 토큰이 없는 요청이라면, null 값을 반환한다.")
+        void givenRequestWithoutToken_whenResolvingAccessToken_thenReturnsNull() {
+            // given
+            Cookie[] cookies = new Cookie[]{};
+            given(request.getCookies()).willReturn(cookies);
+
+            // when
+            String accessToken = jwtTokenProvider.resolveToken(request, TokenType.ACCESS);
+
+            // then
+            assertThat(accessToken).isEqualTo(null);
+        }
+    }
+
+    @Nested
+    @DisplayName("토큰 검증 기능 테스트")
+    class aboutValidatingToken {
+
+        @Test
+        @DisplayName("액세스 토큰 검증시, 유효한 토큰이라면, 참을 반환한다.")
+        void givenProperAccessToken_whenValidatingAccessToken_thenReturnsTrue() {
+            // given
+            String validToken = masterToken;
+
+            // when
+            boolean isTokenValid = jwtTokenProvider.isTokenValid(validToken);
+
+            // then
+            assertThat(isTokenValid).isEqualTo(true);
+        }
+    }
+
+
+    @Nested
+    @DisplayName("권한 조회 기능 테스트")
+    class aboutAuthenticatingToken {
+
+        @Test
+        @DisplayName("액세스 토큰으로부터 권한 조회시, 유효한 사용자 ID를 가지고 있다면, 사용자 정보가 담긴 DTO를 반환한다.")
+        void givenAccessTokenWithProperMemberId_whenGettingAuthentication_thenReturnsMemberDto() {
+            // given
+            String validToken = masterToken;
+            MemberDto mockMemberDto = getMockMemberDto();
+            given(tokenAuthenticationService.getMemberDto("tester")).willReturn(mockMemberDto);
+            UsernamePasswordAuthenticationToken expectedUpat = new UsernamePasswordAuthenticationToken(mockMemberDto, null, mockMemberDto.getAuthorities());
+
+            // when
+            UsernamePasswordAuthenticationToken receivedUpat = jwtTokenProvider.getAuthentication(validToken);
+
+            // then
+            assertThat(receivedUpat.getName()).isEqualTo(expectedUpat.getName());
+            assertThat(receivedUpat.getCredentials()).isEqualTo(receivedUpat.getCredentials());
+        }
+    }
+
+
+    private Cookie createCookie(String key, String value) {
+        return new Cookie(key, value);
+    }
+
+    private MemberDto getMockMemberDto() {
+        return MemberDto.builder()
+                .id("tester00")
+                .email("tester@test.com")
+                .nickname("tester")
+                .role(MemberRole.GUEST)
+                .build();
     }
 }

--- a/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
@@ -1,9 +1,7 @@
 package org.finalproject.TMeRoom.auth.config.jwt;
 
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.security.Keys;
-import org.finalproject.tmeroom.auth.config.jwt.JwtAuthenticationFilter;
 import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
+import org.finalproject.tmeroom.auth.config.jwt.TokenType;
 import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,18 +9,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.MockBeans;
 import org.springframework.test.context.TestPropertySource;
-
-import java.security.Key;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 
 @SpringBootTest(classes = {JwtTokenProvider.class})
-@TestPropertySource(properties = {
-        "JWT_KEY=LongLongLongLongLongLongLongLongTestJWTKey"
-})
+@TestPropertySource(properties = {"JWT_KEY=LongLongLongLongLongLongLongLongTestJWTKey"})
 @DisplayName("JWT 관련 테스트")
 class JwtTokenProviderTest {
 
@@ -43,7 +36,7 @@ class JwtTokenProviderTest {
             String subject = "tester";
 
             // when
-            String accessToken = jwtTokenProvider.createAccessToken(subject);
+            String accessToken = jwtTokenProvider.createToken(subject, TokenType.ACCESS);
 
             // then
             assertThat(accessToken).isNotNull();

--- a/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
@@ -42,4 +42,22 @@ class JwtTokenProviderTest {
             assertThat(accessToken).isNotNull();
         }
     }
+
+    @Nested
+    @DisplayName("액세스 토큰 발급 기능 테스트")
+    class aboutCreatingAccessToken {
+
+        @Test
+        @DisplayName("액세스 토큰 발급시, 서브젝트를 넘기면, 액세스 토큰을 발급한다.")
+        void givenSubject_whenCreatingAccessToken_thenReturnsAccessToken() {
+            // given
+            String subject = "tester";
+
+            // when
+            String accessToken = jwtTokenProvider.createToken(subject, TokenType.ACCESS);
+
+            // then
+            assertThat(accessToken).isNotNull();
+        }
+    }
 }

--- a/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/config/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,52 @@
+package org.finalproject.TMeRoom.auth.config.jwt;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.finalproject.tmeroom.auth.config.jwt.JwtAuthenticationFilter;
+import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
+import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.MockBeans;
+import org.springframework.test.context.TestPropertySource;
+
+import java.security.Key;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@SpringBootTest(classes = {JwtTokenProvider.class})
+@TestPropertySource(properties = {
+        "JWT_KEY=LongLongLongLongLongLongLongLongTestJWTKey"
+})
+@DisplayName("JWT 관련 테스트")
+class JwtTokenProviderTest {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockBean
+    private TokenAuthenticationService tokenAuthenticationService;
+
+    @Nested
+    @DisplayName("액세스 토큰 발급 기능 테스트")
+    class aboutCreatingAccessToken {
+
+        @Test
+        @DisplayName("액세스 토큰 발급시, 서브젝트를 넘기면, 액세스 토큰을 발급한다.")
+        void givenSubject_whenCreatingAccessToken_thenReturnsAccessToken() {
+            // given
+            String subject = "tester";
+
+            // when
+            String accessToken = jwtTokenProvider.createAccessToken(subject);
+
+            // then
+            assertThat(accessToken).isNotNull();
+        }
+    }
+}

--- a/src/test/java/org/finalproject/TMeRoom/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/controller/AuthControllerTest.java
@@ -1,0 +1,136 @@
+package org.finalproject.TMeRoom.auth.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.finalproject.tmeroom.auth.config.SecurityConfig;
+import org.finalproject.tmeroom.auth.controller.AuthController;
+import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
+import org.finalproject.tmeroom.auth.data.dto.response.LoginResponseDto;
+import org.finalproject.tmeroom.auth.service.AuthService;
+import org.finalproject.tmeroom.common.exception.ApplicationException;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(
+        controllers = AuthController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+        },
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @MockBean
+    private AuthService authService;
+
+    @Nested
+    @DisplayName("로그인 요청 테스트")
+    class aboutLogin {
+
+        @Test
+        @DisplayName("로그인 요청을 보내면, 정상적인 요청일 때, 성공 코드와 토큰을 담은 쿠키를 응답으로 반환한다.")
+        void givenProperRequest_whenRequestingLogin_thenReturnsSuccessCodeWithTokenCookie() throws Exception {
+
+            // Given
+            String id = "tester00";
+            String password = "test";
+            LoginRequestDto requestDto = LoginRequestDto
+                    .builder()
+                    .id(id)
+                    .pw(password)
+                    .build();
+            LoginResponseDto responseDto = LoginResponseDto.builder()
+                    .accessToken("mockAccessToken")
+                    .build();
+            given(authService.login(any(LoginRequestDto.class))).willReturn(responseDto);
+
+            // When & Then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.[?(@.resultCode == 'SUCCESS')]").exists())
+                    .andExpect(result -> {
+                        List<String> setCookieHeaders = result.getResponse().getHeaders(HttpHeaders.SET_COOKIE);
+                        assertThat(setCookieHeaders).isNotNull().hasSize(1);
+                        String setCookieHeaderValue = setCookieHeaders.get(0);
+                        assertThat(setCookieHeaderValue).contains("accessToken");
+                        assertThat(setCookieHeaderValue).contains("HttpOnly");
+                        assertThat(setCookieHeaderValue).contains("Max-Age");
+                    });
+        }
+
+        @Test
+        @DisplayName("로그인 요청을 보내면, 잘못된 아이디라면, 에러 코드를 반환한다.")
+        void givenWrongId_whenRequestingLogin_thenReturnsIsNotFound() throws Exception {
+            // Given
+            String id = "wrongId";
+            String password = "password";
+            LoginRequestDto requestDto = LoginRequestDto
+                    .builder()
+                    .id(id)
+                    .pw(password)
+                    .build();
+            given(authService.login(any(LoginRequestDto.class))).willThrow(
+                    new ApplicationException(ErrorCode.USER_NOT_FOUND)
+            );
+
+            // When & Then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.[?(@.resultCode == 'USER_NOT_FOUND')]").exists());
+        }
+
+        @Test
+        @DisplayName("로그인 요청을 보내면, 잘못된 비밀번호라면, 에러 코드를 반환한다.")
+        void givenWrongPassword_whenRequestingLogin_thenReturnsIsUnauthorized() throws Exception {
+            // Given
+            String id = "tester";
+            String password = "wrongPw";
+            LoginRequestDto requestDto = LoginRequestDto
+                    .builder()
+                    .id(id)
+                    .pw(password)
+                    .build();
+            given(authService.login(any(LoginRequestDto.class))).willThrow(
+                    new ApplicationException(ErrorCode.INVALID_PASSWORD)
+            );
+
+            // When & Then
+            mockMvc.perform(post("/api/v1/auth/login")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsBytes(requestDto))
+                    ).andDo(print())
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.[?(@.resultCode == 'INVALID_PASSWORD')]").exists());
+        }
+    }
+
+}

--- a/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
@@ -1,0 +1,130 @@
+package org.finalproject.TMeRoom.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.finalproject.tmeroom.auth.config.jwt.JwtTokenProvider;
+import org.finalproject.tmeroom.auth.config.jwt.TokenType;
+import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
+import org.finalproject.tmeroom.auth.data.dto.response.LoginResponseDto;
+import org.finalproject.tmeroom.auth.service.AuthService;
+import org.finalproject.tmeroom.common.exception.ApplicationException;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.finalproject.tmeroom.member.constant.MemberRole;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
+import org.finalproject.tmeroom.member.data.entity.Member;
+import org.finalproject.tmeroom.member.repository.MemberRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest(classes = {AuthService.class})
+@TestPropertySource(properties = {"JWT_KEY=LongLongLongLongLongLongLongLongTestJWTKey"})
+@DisplayName("인증 서비스 로직 테스트")
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @MockBean
+    private PasswordEncoder passwordEncoder;
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @Nested
+    @DisplayName("로그인 기능 테스트")
+    class aboutLogin {
+
+        @Test
+        @DisplayName("로그인 요청시, 올바른 요청이라면, 토큰을 발급한다.")
+        void givenProperRequestDto_whenLoggingIn_thenReturnsToken() {
+            // Given
+            LoginRequestDto mockRequestDto = getMockRequestDto();
+            Member mockMember = getMockMember();
+            String mockAccessToken = "mockAccessToken";
+            given(memberRepository.findById(mockRequestDto.getId())).willReturn(Optional.of(mockMember));
+            given(passwordEncoder.matches(mockRequestDto.getPw(), mockMember.getPw())).willReturn(true);
+            given(jwtTokenProvider.createToken(mockMember.getId(), TokenType.ACCESS)).willReturn(mockAccessToken);
+
+            // When
+            LoginResponseDto responseDto = authService.login(mockRequestDto);
+
+            // Then
+            then(memberRepository).should().findById(mockRequestDto.getId());
+            then(passwordEncoder).should().matches(mockRequestDto.getPw(), mockMember.getPw());
+            then(jwtTokenProvider).should().createToken(mockMember.getId(), TokenType.ACCESS);
+            assertThat(responseDto)
+                    .hasFieldOrPropertyWithValue("accessToken", mockAccessToken);
+        }
+
+        @Test
+        @DisplayName("로그인 요청시, 존재하지 않는 유저ID라면, 예외를 발생시킨다.")
+        void givenWrongUserId_whenLoggingIn_thenThrowsUserNotFoundException() {
+            // Given
+            LoginRequestDto mockRequestDto = getMockRequestDto();
+            given(memberRepository.findById(mockRequestDto.getId())).willReturn(Optional.empty());
+
+            // When
+            ApplicationException e = assertThrows(ApplicationException.class,
+                    () -> authService.login(mockRequestDto));
+
+            // Then
+            then(memberRepository).should().findById(mockRequestDto.getId());
+            then(passwordEncoder).should().encode(any());
+            then(passwordEncoder).shouldHaveNoMoreInteractions();
+            then(jwtTokenProvider).shouldHaveNoInteractions();
+            assertEquals(e.getErrorCode(), ErrorCode.USER_NOT_FOUND);
+        }
+
+        @Test
+        @DisplayName("로그인 요청시, 잘못된 비밀번호라면, 예외를 발생시킨다.")
+        void givenWrongPassword_whenLoggingIn_thenThrowsUserNotFoundException() {
+            // Given
+            LoginRequestDto mockRequestDto = getMockRequestDto();
+            Member mockMember = getMockMember();
+            given(memberRepository.findById(mockRequestDto.getId())).willReturn(Optional.of(mockMember));
+            given(passwordEncoder.matches(mockRequestDto.getPw(), mockMember.getPw())).willReturn(false);
+
+            // When
+            ApplicationException e = assertThrows(ApplicationException.class,
+                    () -> authService.login(mockRequestDto));
+
+            // Then
+            then(memberRepository).should().findById(mockRequestDto.getId());
+            then(passwordEncoder).should().matches(mockRequestDto.getPw(), mockMember.getPw());
+            then(jwtTokenProvider).shouldHaveNoInteractions();
+            assertEquals(e.getErrorCode(), ErrorCode.INVALID_PASSWORD);
+        }
+    }
+
+    private LoginRequestDto getMockRequestDto() {
+        return LoginRequestDto.builder()
+                .id("tester00")
+                .pw("test")
+                .build();
+    }
+
+    private Member getMockMember() {
+        return Member.builder()
+                .id("tester00")
+                .pw("encodedPw")
+                .email("tester@test.com")
+                .nickname("tester")
+                .role(MemberRole.USER)
+                .build();
+    }
+}


### PR DESCRIPTION
- 사용자가 로그인 요청을 보내면, ID와 PW를 확인하고 AccessToken을 HTTPOnly 쿠키에 담아 반환하는 코드 작성.
  - 로그인 요청을 처리하는 `AuthController`와 로직을 담당하는 `AuthService`, 그리고 각 로직을 테스트하는 테스트 코드 작성
  - 토큰 발급 로직을 위한 `TokenProvider` 클래스를 작성하고, 테스트 코드를 작성
    - 헤더로부터 토큰을 추출하고, 토큰의 유효성을 검증하는 로직도 추가
  - Spring Security에서 해당 로직을 사용할 수 있도록 요청을 필터링하는 `JwtAuthenticationFilter`을 작성, 필터 체인에 추가