### PR TITLE
🔧	: Redis 연결을 위한 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+
+	// Redis 관련 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/finalproject/tmeroom/common/config/RedisConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/common/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package org.finalproject.tmeroom.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        return redisTemplate;
+    }
+}

--- a/src/main/resources/config/redis/application.yml
+++ b/src/main/resources/config/redis/application.yml
@@ -1,0 +1,26 @@
+spring:
+  config:
+    activate:
+      on-profile:
+        - local
+        - test
+
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile:
+        - dev
+        - prod
+
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT}
+      password: ${REDIS_PASSWORD}


### PR DESCRIPTION
- **중요!!!** application.yml 을 분리해 관리하기 위해 **아래 환경변수를 추가해야함**
  - spring.config.additional-location=classpath:config/*/
- redis 가 존재한다는 가정 하에, redis 를 사용할 수 있도록 설정을 추가
  - local 이나 test 환경이라면 localhost에서 6379 포트로 연결
  - dev나 prod 환경이라면 환경변수로 추가해줘야 함
- Service 로직에서 Redis 사용할 수 있도록 Config 작성
  - RedisTemplate<String, String> 을 Autowire 받아 사용 가능