### PR TITLE
🔧	: Email 전송을 위한 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ dependencies {
 
 	// Redis 관련 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// email 관련 의존성
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/finalproject/tmeroom/common/config/EmailConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/common/config/EmailConfig.java
@@ -1,0 +1,36 @@
+package org.finalproject.tmeroom.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class EmailConfig implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "mailAsync")
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("MailExecutor-");
+        executor.initialize();
+        return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) ->
+                log.error("Exception handler for async method '" + method.toGenericString()
+                        + "' threw unexpected exception itself", ex);
+    }
+}

--- a/src/main/resources/config/mail/application.yml
+++ b/src/main/resources/config/mail/application.yml
@@ -1,0 +1,12 @@
+spring:
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_ADDRESS}
+    password: ${GMAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true


### PR DESCRIPTION
- **중요!!!** 환경변수로 GMAIL_ADDRESS 와 GMAIL_PASSWORD 추가 필요
  - 여기서 GMAIL_PASSWORD 는 로그인시 사용하는 비밀번호가 아닌, "앱 비밀번호 설정" 을 통해 얻는 비밀번호
  - [[앱 비밀번호 생성시 참고](https://support.google.com/accounts/answer/185833?hl=ko)]
- 이메일 전송 처리를 비동기로 하기 위해 EmailConfig 클래스 작성
  - 실제로 전송하는 로직에 `@Async("mailThread")`를 달아 사용