### PR TITLE
✨	: 이메일 인증 로직 구현

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     DUPLICATE_ID(HttpStatus.BAD_REQUEST, "입력한 유저 정보 중복"),
-    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "입력한 유저 정보 중복")
+    DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "입력한 유저 정보 중복"),
+    EMAIL_ALREADY_CONFIRMED(HttpStatus.BAD_REQUEST, "이메일 인증 이미 완료"),
+    CONFIRM_CODE_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 이메일 인증 코드"),
     //    ==== 여기까지 작성 ====
     ;
 

--- a/src/main/java/org/finalproject/tmeroom/common/service/MailService.java
+++ b/src/main/java/org/finalproject/tmeroom/common/service/MailService.java
@@ -1,0 +1,37 @@
+package org.finalproject.tmeroom.common.service;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    @Async("mailAsync")
+    public void sendEmail(String emailAddress, String subject, String content, boolean isHtml, boolean isMultipart) {
+
+        MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+        try {
+            MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, isMultipart);
+
+            helper.setTo(emailAddress);
+            helper.setSubject(subject);
+            helper.setText(content, isHtml);
+
+            mailSender.send(mimeMessage);
+        } catch (MessagingException | MailException e) {
+            log.error("Exception thrown during email creation, message={}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
+++ b/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
@@ -32,15 +32,15 @@ public class MemberController {
         return Response.success();
     }
 
-    @PostMapping("/email/confirm/{confirm-code}")
-    public Response<Void> confirmMail(@PathVariable("confirm-code") String confirmCode) {
+    @PostMapping("/email/confirm/{confirmCode}")
+    public Response<Void> confirmMail(@PathVariable String confirmCode) {
         memberService.confirmEmail(confirmCode);
         return Response.success();
     }
 
     // TODO: 프론트 없을 때 테스트 용도. 프론트 완료되면 삭제 예정
-    @GetMapping("/email/confirm/{confirm-code}")
-    public Response<Void> confirmMailTemp(@PathVariable("confirm-code") String confirmCode) {
+    @GetMapping("/email/confirm/{confirmCode}")
+    public Response<Void> confirmMailTemp(@PathVariable String confirmCode) {
         memberService.confirmEmail(confirmCode);
         return Response.success();
     }

--- a/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
+++ b/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
@@ -2,10 +2,16 @@ package org.finalproject.tmeroom.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.common.data.dto.Response;
-import org.finalproject.tmeroom.member.data.dto.request.EmailConfirmRequestDto;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
 import org.finalproject.tmeroom.member.data.dto.request.MemberCreateRequestDto;
 import org.finalproject.tmeroom.member.service.MemberService;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -20,14 +26,20 @@ public class MemberController {
         return Response.success();
     }
 
-    @PostMapping("/email/confirm")
-    public Response<Void> confirmMailTemp(@RequestBody EmailConfirmRequestDto requestDto) {
-        memberService.confirmEmail(requestDto.getConfirmCode());
+    @GetMapping("/email/confirm/resend")
+    public Response<Void> resendConfirmMail(@AuthenticationPrincipal MemberDto memberDto) {
+        memberService.sendConfirmMail(memberDto);
+        return Response.success();
+    }
+
+    @PostMapping("/email/confirm/{confirm-code}")
+    public Response<Void> confirmMail(@PathVariable("confirm-code") String confirmCode) {
+        memberService.confirmEmail(confirmCode);
         return Response.success();
     }
 
     // TODO: 프론트 없을 때 테스트 용도. 프론트 완료되면 삭제 예정
-    @GetMapping("/confirm/{confirm-code}")
+    @GetMapping("/email/confirm/{confirm-code}")
     public Response<Void> confirmMailTemp(@PathVariable("confirm-code") String confirmCode) {
         memberService.confirmEmail(confirmCode);
         return Response.success();

--- a/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
+++ b/src/main/java/org/finalproject/tmeroom/member/controller/MemberController.java
@@ -2,12 +2,10 @@ package org.finalproject.tmeroom.member.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.common.data.dto.Response;
+import org.finalproject.tmeroom.member.data.dto.request.EmailConfirmRequestDto;
 import org.finalproject.tmeroom.member.data.dto.request.MemberCreateRequestDto;
 import org.finalproject.tmeroom.member.service.MemberService;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/member")
@@ -19,6 +17,19 @@ public class MemberController {
     @PostMapping
     public Response<Void> createMember(@RequestBody MemberCreateRequestDto requestDto) {
         memberService.createMember(requestDto);
+        return Response.success();
+    }
+
+    @PostMapping("/email/confirm")
+    public Response<Void> confirmMailTemp(@RequestBody EmailConfirmRequestDto requestDto) {
+        memberService.confirmEmail(requestDto.getConfirmCode());
+        return Response.success();
+    }
+
+    // TODO: 프론트 없을 때 테스트 용도. 프론트 완료되면 삭제 예정
+    @GetMapping("/confirm/{confirm-code}")
+    public Response<Void> confirmMailTemp(@PathVariable("confirm-code") String confirmCode) {
+        memberService.confirmEmail(confirmCode);
         return Response.success();
     }
 }

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/request/EmailConfirmRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/request/EmailConfirmRequestDto.java
@@ -1,0 +1,9 @@
+package org.finalproject.tmeroom.member.data.dto.request;
+
+import lombok.Data;
+
+@Data
+public class EmailConfirmRequestDto {
+
+    private String confirmCode;
+}

--- a/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.finalproject.tmeroom.common.data.entity.BaseTimeEntity;
+import org.finalproject.tmeroom.common.exception.ApplicationException;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
 import org.finalproject.tmeroom.member.constant.MemberRole;
 
 /**
@@ -47,6 +49,13 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.email = email;
         this.role = role == null ? MemberRole.GUEST : role;
+    }
+
+    public void confirmEmail() {
+        if (!role.equals(MemberRole.GUEST)) {
+            throw new ApplicationException(ErrorCode.EMAIL_ALREADY_CONFIRMED);
+        }
+        role = MemberRole.USER;
     }
 
 }

--- a/src/main/java/org/finalproject/tmeroom/member/repository/EmailConfirmRedisRepository.java
+++ b/src/main/java/org/finalproject/tmeroom/member/repository/EmailConfirmRedisRepository.java
@@ -1,0 +1,47 @@
+package org.finalproject.tmeroom.member.repository;
+
+import java.time.Duration;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * 작성자: 김태민
+ * 작성 일자: 2023-09-19
+ * 이메일 인증 코드를 Redis에 저장하는 로직
+ */
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class EmailConfirmRedisRepository implements EmailConfirmRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private final static Duration ITEM_TTL = Duration.ofDays(1);
+    private final static String REDIS_PREFIX = "EMAIL_CODE:";
+
+    private String getKey(String key) {
+        return REDIS_PREFIX + key;
+    }
+
+    @Override
+    public void save(String confirmCode, String memberId) {
+        String key = getKey(confirmCode);
+        redisTemplate.opsForValue().set(key, memberId, ITEM_TTL);
+    }
+
+    @Override
+    public Optional<String> findMemberIdByConfirmCode(String confirmCode) {
+        String key = getKey(confirmCode);
+        String memberId = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(memberId);
+    }
+
+    @Override
+    public void deleteByConfirmCode(String confirmCode) {
+        String key = getKey(confirmCode);
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/member/repository/EmailConfirmRepository.java
+++ b/src/main/java/org/finalproject/tmeroom/member/repository/EmailConfirmRepository.java
@@ -1,0 +1,17 @@
+package org.finalproject.tmeroom.member.repository;
+
+import java.util.Optional;
+/**
+ * 작성자: 김태민
+ * 작성 일자: 2023-09-19
+ * 이메일 인증 코드를 저장하는 로직
+ */
+public interface EmailConfirmRepository {
+
+    void save(String confirmCode, String memberId);
+
+    Optional<String> findMemberIdByConfirmCode(String confirmCode);
+
+    void deleteByConfirmCode(String confirmCode);
+
+}

--- a/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
+++ b/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
@@ -76,7 +76,7 @@ public class MemberService {
         sb.append("<h3>인증 링크</h3>");
         sb.append("<div style='font-size:130%'>");
         sb.append("<strong>");
-        sb.append("localhost:8080/api/v1/member/confirm/" + confirmCode + "</strong></div><br/>");
+        sb.append("localhost:8080/api/v1/email/member/confirm/" + confirmCode + "</strong></div><br/>");
         sb.append("</div></br></br>");
         sb.append("<p>감사합니다.</p>");
         sb.append("</div>");

--- a/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
+++ b/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
@@ -1,28 +1,86 @@
 package org.finalproject.tmeroom.member.service;
 
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.common.exception.ApplicationException;
 import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.finalproject.tmeroom.common.service.MailService;
+import org.finalproject.tmeroom.member.data.dto.MemberDto;
 import org.finalproject.tmeroom.member.data.dto.request.MemberCreateRequestDto;
 import org.finalproject.tmeroom.member.data.dto.response.MemberCreateResponseDto;
 import org.finalproject.tmeroom.member.data.entity.Member;
+import org.finalproject.tmeroom.member.repository.EmailConfirmRepository;
 import org.finalproject.tmeroom.member.repository.MemberRepository;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 작성자: 김태민
+ * 작성 일자: 2023-09-19
+ * 다음과 같은 회원 관련 로직을 포함
+ * 회원 가입, 이메일 인증
+ */
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class MemberService {
 
     private final PasswordEncoder passwordEncoder;
     private final MemberRepository memberRepository;
+    private final EmailConfirmRepository emailConfirmRepository;
+    private final MailService mailService;
 
     public MemberCreateResponseDto createMember(MemberCreateRequestDto requestDto) {
 
         checkIdDuplicate(requestDto.getMemberId());
         checkEmailDuplicate(requestDto.getEmail());
         Member savedMember = memberRepository.save(requestDto.toEntity(passwordEncoder));
+        sendConfirmMail(MemberDto.from(savedMember));
         return MemberCreateResponseDto.from(savedMember);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW) // Redis에 인증 메일 정보 저장을 실패했다고 회원 가입까지 롤백되면 안됨
+    public void sendConfirmMail(MemberDto memberDto) {
+
+        String confirmCode = UUID.randomUUID().toString();
+        emailConfirmRepository.save(confirmCode, memberDto.getId());
+
+        String subject = "[티미룸] 인증 링크를 발송해 드립니다.";
+        String content = getConfirmMailContent(confirmCode);
+        mailService.sendEmail(memberDto.getEmail(), subject, content, true, false);
+    }
+
+    public void confirmEmail(String confirmCode) {
+
+        String memberId = emailConfirmRepository.findMemberIdByConfirmCode(confirmCode)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.CONFIRM_CODE_NOT_VALID));
+
+        Member foundMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
+
+        foundMember.confirmEmail();
+
+        emailConfirmRepository.deleteByConfirmCode(confirmCode);
+
+    }
+
+    // TODO: 요청을 백엔드로 직접 보내도록 했는데, 프론트가 짜여지면 링크를 수정해야 함.
+    private String getConfirmMailContent(String confirmCode) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div style='margin:20px;'>");
+        sb.append("<p>티미룸 인증 링크를 발송해 드립니다.</p>");
+        sb.append("<br>");
+        sb.append("<div align='center' style='border:1px solid black; font-family:verdana'>");
+        sb.append("<h3>인증 링크</h3>");
+        sb.append("<div style='font-size:130%'>");
+        sb.append("<strong>");
+        sb.append("localhost:8080/api/v1/member/confirm/" + confirmCode + "</strong></div><br/>");
+        sb.append("</div></br></br>");
+        sb.append("<p>감사합니다.</p>");
+        sb.append("</div>");
+        return sb.toString();
     }
 
     private void checkIdDuplicate(String id) {


### PR DESCRIPTION
이메일 인증 로직을 위해 아래와 같은 기능을 추가했습니다.
- 회원가입 즉시 인증 이메일을 발송
- `/email/confirm/{confirm-code}`로 POST 요청을 보내면 이메일 인증을 확정
- 로그인 한 상태로 `/email/confirm/resend`로 GET 요청을 보내면 인증 메일을 재전송
