### PR TITLE
🎨	: JWT 인증 실패 오류 세분화

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/auth/config/SecurityConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/SecurityConfig.java
@@ -12,19 +12,31 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
+/**
+ * 작성자: 김태민
+ * 작성일자: 2023-09-13
+ * 보안 관련 필터 설정
+ * 요청이 컨트롤러에 닿기 전에 인증, 인가 및 여러 보안 문제를 사전에 차단하는 기능을 함
+ */
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+    private final AccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                .httpBasic(AbstractHttpConfigurer::disable)
+
                 // REST API는 CSRF 대응 필요 없음
                 .csrf(AbstractHttpConfigurer::disable)
 
@@ -32,14 +44,22 @@ public class SecurityConfig {
                 .cors(Customizer.withDefaults())
 
                 // 세션 관리 비활성화
-                .sessionManagement((sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(
+                        (sessionManagement) -> sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 // URI 인증, 인가 설정
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("api/v1/lecture/**").authenticated()
                         .anyRequest().permitAll())
 
                 // JWT 인증필터 등록
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
+
+                .exceptionHandling(exceptionHandling -> exceptionHandling
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+        ;
 
         return http.build();
     }

--- a/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package org.finalproject.tmeroom.auth.config.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.finalproject.tmeroom.common.data.dto.Response;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+/**
+ * 작성자: 김태민
+ * 작성 일자: 2023-09-20
+ * 인가 실패 시 응답 처리
+ */
+@Slf4j
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException exception) throws IOException {
+        log.info(exception.getMessage() +
+                " for request of URI: [" + request.getRequestURI() + "]" +
+                " requested by Account: " + request.getUserPrincipal().getName());
+        ErrorCode errorCode = ErrorCode.AUTHORIZATION_ERROR;
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getStatus().value());
+        response.getWriter().write(Response.error(errorCode.name(), errorCode.getMessage()).toStream());
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package org.finalproject.tmeroom.auth.config.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+/**
+ * 작성자: 김태민
+ * 작성 일자: 2023-09-20
+ * 인증 실패 시 응답 처리
+ * 실제 메시지는 JwtAuthenticationFilter에서 담지만, 이 클래스가 없으면 메시지 자체가 담기지 않음
+ */
+@Slf4j
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) {}
+}

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
@@ -4,7 +4,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.finalproject.tmeroom.common.data.dto.Response;
@@ -42,7 +41,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             if (!jwtTokenProvider.isTokenValid(token)) {
-                writeResult(response, ErrorCode.TOKEN_EXPIRED);
+                writeResult(response, ErrorCode.TOKEN_INVALID);
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtTokenProvider.java
@@ -1,21 +1,25 @@
 package org.finalproject.tmeroom.auth.config.jwt;
 
-import io.jsonwebtoken.*;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.auth.service.TokenAuthenticationService;
 import org.finalproject.tmeroom.member.data.dto.MemberDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.stereotype.Component;
-
-import java.nio.charset.StandardCharsets;
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Date;
 
 /**
  * 작성자: 김태민
@@ -55,7 +59,9 @@ public class JwtTokenProvider {
     }
 
     private Cookie findCookieByName(String name, HttpServletRequest request) {
-        return Arrays.stream(request.getCookies())
+        Cookie[] cookies = Optional.ofNullable(request.getCookies())
+                .orElse(new Cookie[0]);
+        return Arrays.stream(cookies)
                 .filter(cookie -> cookie.getName().equals(name))
                 .findFirst()
                 .orElse(new Cookie(name, null));

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -16,7 +16,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류 발생"),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰 없음"),
-    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰 유효 기간 만료"),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰"),
     AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 필요"),
     INVALID_PERMISSION(HttpStatus.FORBIDDEN, "소유자 불일치"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -14,6 +14,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //    ==== 여기서부터 작성 ====
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
+    AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류 발생"),
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰 없음"),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰 유효 기간 만료"),
+    AUTHORIZATION_ERROR(HttpStatus.FORBIDDEN, "권한 필요"),
     INVALID_PERMISSION(HttpStatus.FORBIDDEN, "소유자 불일치"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "유저가 존재하지 않습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),


### PR DESCRIPTION
- 기존에는 인증 실패 원인 메시지 없이 상태 코드 403만 반환했는데, 이 때문에 무엇 때문에 인증이 실패했는지 알기 어려웠음
  - 토큰이 없으면 없다는 메시지를, 유효하지 않으면 유효하지 않다는 메시지를 응답에 담도록 수정