### PR TITLE
✨	: 유효성 검증 기능 추가

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/TMeRoomApplication.java
+++ b/src/main/java/org/finalproject/tmeroom/TMeRoomApplication.java
@@ -2,13 +2,12 @@ package org.finalproject.tmeroom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 public class TMeRoomApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(TMeRoomApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(TMeRoomApplication.class, args);
+    }
 
 }

--- a/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/exception/CustomAuthenticationEntryPoint.java
@@ -2,7 +2,13 @@ package org.finalproject.tmeroom.auth.config.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.finalproject.tmeroom.common.data.dto.Response;
+import org.finalproject.tmeroom.common.exception.ErrorCode;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -11,13 +17,26 @@ import org.springframework.stereotype.Component;
  * 작성자: 김태민
  * 작성 일자: 2023-09-20
  * 인증 실패 시 응답 처리
- * 실제 메시지는 JwtAuthenticationFilter에서 담지만, 이 클래스가 없으면 메시지 자체가 담기지 않음
  */
 @Slf4j
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
+    private static final Map<String, ErrorCode> authErrorMap = Stream.of(ErrorCode.TOKEN_NOT_FOUND,
+                    ErrorCode.TOKEN_INVALID)
+            .collect(Collectors.toUnmodifiableMap(ErrorCode::name, e -> e));
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response,
-                         AuthenticationException authException) {}
+                         AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = resolveErrorCode(response.getHeader("jwt-error"));
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorCode.getStatus().value());
+        response.getWriter().write(Response.error(errorCode.name(), errorCode.getMessage()).toStream());
+    }
+
+    private ErrorCode resolveErrorCode(String errorName) {
+        return authErrorMap.getOrDefault(errorName, ErrorCode.AUTHENTICATION_ERROR);
+    }
 }

--- a/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/config/jwt/JwtAuthenticationFilter.java
@@ -4,16 +4,14 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.finalproject.tmeroom.common.data.dto.Response;
 import org.finalproject.tmeroom.common.exception.ErrorCode;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
 
 /**
  * 작성자: 김태민
@@ -35,13 +33,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // 토큰 유효성 체크
             if (token == null) {
-                writeResult(response, ErrorCode.TOKEN_NOT_FOUND);
+                response.setHeader("jwt-error", ErrorCode.TOKEN_NOT_FOUND.name());
                 filterChain.doFilter(request, response);
                 return;
             }
 
             if (!jwtTokenProvider.isTokenValid(token)) {
-                writeResult(response, ErrorCode.TOKEN_INVALID);
+                response.setHeader("jwt-error", ErrorCode.TOKEN_INVALID.name());
                 filterChain.doFilter(request, response);
                 return;
             }
@@ -51,17 +49,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
         } catch (RuntimeException e) {
-            writeResult(response, ErrorCode.AUTHENTICATION_ERROR);
             filterChain.doFilter(request, response);
             return;
         }
         filterChain.doFilter(request, response);
-    }
-
-    private void writeResult(HttpServletResponse response, ErrorCode errorCode) throws IOException{
-        response.setContentType("application/json");
-        response.setCharacterEncoding("UTF-8");
-        response.setStatus(errorCode.getStatus().value());
-        response.getWriter().write(Response.error(errorCode.name(), errorCode.getMessage()).toStream());
     }
 }

--- a/src/main/java/org/finalproject/tmeroom/auth/controller/AuthController.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package org.finalproject.tmeroom.auth.controller;
 
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.auth.config.jwt.TokenType;
 import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
@@ -22,7 +23,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public Response<Void> login(@RequestBody LoginRequestDto requestDto, HttpServletResponse response) {
+    public Response<Void> login(@RequestBody @Valid LoginRequestDto requestDto, HttpServletResponse response) {
 
         LoginResponseDto responseDto = authService.login(requestDto);
 

--- a/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
@@ -1,5 +1,8 @@
 package org.finalproject.tmeroom.auth.data.dto.request;
 
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.CANNOT_BE_NULL;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
 import lombok.Data;
 
@@ -7,6 +10,8 @@ import lombok.Data;
 @Builder
 public class LoginRequestDto {
 
+    @NotBlank(message = CANNOT_BE_NULL)
     private String id;
+    @NotBlank(message = CANNOT_BE_NULL)
     private String pw;
 }

--- a/src/main/java/org/finalproject/tmeroom/comment/controller/CommentController.java
+++ b/src/main/java/org/finalproject/tmeroom/comment/controller/CommentController.java
@@ -13,7 +13,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -23,7 +30,9 @@ public class CommentController {
 
     // 댓글 조회
     @GetMapping("/lecture/{lectureCode}/question/{questionId}/comments")
-    public Response<Page<CommentDetailResponseDto>> readComments(@PathVariable Long lectureCode, @PathVariable Long questionId, @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<CommentDetailResponseDto>> readComments(@PathVariable Long lectureCode,
+                                                                 @PathVariable Long questionId,
+                                                                 @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<CommentDetailResponseDto> dtoList = commentService.readComments(questionId, pageable);
 
         return Response.success(dtoList);
@@ -31,7 +40,9 @@ public class CommentController {
 
     // 댓글 게시
     @PostMapping("/lecture/{lectureCode}/question/{questionId}/comment")
-    public Response<Void> createComment(@PathVariable String lectureCode, @PathVariable Long questionId, @AuthenticationPrincipal MemberDto memberDto, @RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto) {
+    public Response<Void> createComment(@PathVariable String lectureCode, @PathVariable Long questionId,
+                                        @AuthenticationPrincipal MemberDto memberDto,
+                                        @RequestBody @Valid CommentCreateRequestDto commentCreateRequestDto) {
         commentService.createComment(questionId, commentCreateRequestDto, memberDto);
 
         return Response.success();
@@ -39,7 +50,9 @@ public class CommentController {
 
     // 댓글 수정
     @PutMapping("/lecture/{lectureCode}/question/{questionId}/comment/{commentId}")
-    public Response<Void> updateComment(@PathVariable String lectureCode, @PathVariable Long questionId, @PathVariable Long commentId, @AuthenticationPrincipal MemberDto memberDto, @RequestBody @Valid CommentUpdateRequestDto requestDto) {
+    public Response<Void> updateComment(@PathVariable String lectureCode, @PathVariable Long questionId,
+                                        @PathVariable Long commentId, @AuthenticationPrincipal MemberDto memberDto,
+                                        @RequestBody @Valid CommentUpdateRequestDto requestDto) {
         commentService.updateComment(commentId, requestDto, memberDto);
 
         return Response.success();
@@ -47,7 +60,8 @@ public class CommentController {
 
     // 댓글 삭제
     @DeleteMapping("/lecture/{lectureCode}/question/{questionId}/comment/{commentId}")
-    public Response<Void> deleteComment(@PathVariable String lectureCode, @PathVariable Long questionId, @PathVariable Long commentId, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> deleteComment(@PathVariable String lectureCode, @PathVariable Long questionId,
+                                        @PathVariable Long commentId, @AuthenticationPrincipal MemberDto memberDto) {
         commentService.deleteComment(commentId, memberDto);
 
         return Response.success();

--- a/src/main/java/org/finalproject/tmeroom/comment/data/dto/request/CommentCreateRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/comment/data/dto/request/CommentCreateRequestDto.java
@@ -1,5 +1,10 @@
 package org.finalproject.tmeroom.comment.data.dto.request;
 
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.CANNOT_BE_NULL;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.COMMENT_OVER_MAX;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import org.finalproject.tmeroom.comment.data.entity.Comment;
 import org.finalproject.tmeroom.member.data.entity.Member;
@@ -7,13 +12,16 @@ import org.finalproject.tmeroom.question.data.entity.Question;
 
 @Getter
 public class CommentCreateRequestDto {
+
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Max(value = 10000, message = COMMENT_OVER_MAX)
     String content;
 
     public CommentCreateRequestDto(String content) {
         this.content = content;
     }
 
-    public Comment toEntity(Member commenter, Question question){
+    public Comment toEntity(Member commenter, Question question) {
         return Comment.builder()
                 .commenter(commenter)
                 .content(content)

--- a/src/main/java/org/finalproject/tmeroom/comment/data/dto/request/CommentUpdateRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/comment/data/dto/request/CommentUpdateRequestDto.java
@@ -1,9 +1,17 @@
 package org.finalproject.tmeroom.comment.data.dto.request;
 
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.CANNOT_BE_NULL;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.COMMENT_OVER_MAX;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
 public class CommentUpdateRequestDto {
+
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Max(value = 10000, message = COMMENT_OVER_MAX)
     String content;
 
     public CommentUpdateRequestDto(String content) {

--- a/src/main/java/org/finalproject/tmeroom/common/data/dto/ValidationMessageDto.java
+++ b/src/main/java/org/finalproject/tmeroom/common/data/dto/ValidationMessageDto.java
@@ -1,0 +1,25 @@
+package org.finalproject.tmeroom.common.data.dto;
+
+import lombok.Getter;
+import org.springframework.validation.FieldError;
+
+/**
+ * 작성자: 김태민
+ * 작성일자: 2023-09-20
+ * 검증 실패시 실패한 필드명과 실패 메시지를 담음
+ */
+@Getter
+public class ValidationMessageDto {
+
+    String field;
+    String message;
+
+    private ValidationMessageDto(String field, String message) {
+        this.field = field;
+        this.message = message;
+    }
+
+    public static ValidationMessageDto from(FieldError fieldError) {
+        return new ValidationMessageDto(fieldError.getField(), fieldError.getDefaultMessage());
+    }
+}

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     //    ==== 여기서부터 작성 ====
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러 발생"),
+    REQUEST_PARSE_ERROR(HttpStatus.BAD_REQUEST, "필드 검증 실패"),
     AUTHENTICATION_ERROR(HttpStatus.UNAUTHORIZED, "인증 중 오류 발생"),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "쿠키에 토큰 없음"),
     TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰"),

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ValidationMessage.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ValidationMessage.java
@@ -1,4 +1,10 @@
 package org.finalproject.tmeroom.common.exception;
 
 public class ValidationMessage {
+    public static final String CANNOT_BE_NULL = "필수로 입력되어야 합니다.";
+    public static final String UNMATCHED_USERNAME = "아이디는 4자 이상, 15자 이하의 소문자, 숫자 혹은 \"_\" 의 조합이어야 합니다.";
+    public static final String UNMATCHED_PASSWORD = "비밀번호는 6자 이상, 100자 이하의 알파벳, 숫자의 조합이어야 합니다.";
+    public static final String UNMATCHED_EMAIL = "형식에 맞는 이메일 주소여야 합니다.";
+    public static final String UNMATCHED_NICKNAME = "닉네임은 20자 이하이어야 합니다.";
+    public static final String COMMENT_OVER_MAX = "댓글은 만 자 이상 적을 수 없습니다.";
 }

--- a/src/main/java/org/finalproject/tmeroom/common/exception/ValidationMessage.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ValidationMessage.java
@@ -1,0 +1,4 @@
+package org.finalproject.tmeroom.common.exception;
+
+public class ValidationMessage {
+}

--- a/src/main/java/org/finalproject/tmeroom/lecture/controller/LectureController.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/controller/LectureController.java
@@ -19,7 +19,14 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1")
@@ -30,14 +37,17 @@ public class LectureController {
     private final StudentService studentService;
 
     @PostMapping("/lecture")
-    public Response<LectureCreateResponseDto> createLecture(@RequestBody LectureCreateRequestDto lectureCreateRequestDto, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<LectureCreateResponseDto> createLecture(
+            @RequestBody @Valid LectureCreateRequestDto lectureCreateRequestDto,
+            @AuthenticationPrincipal MemberDto memberDto) {
         lectureCreateRequestDto.setMemberDTO(memberDto);
         LectureCreateResponseDto lectureCreateResponseDto = lectureService.createLecture(lectureCreateRequestDto);
         return Response.success(lectureCreateResponseDto);
     }
 
     @PutMapping("/lecture/{lectureCode}")
-    public Response<Void> updateLecture(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto, @RequestBody @Valid LectureUpdateRequestDto requestDto) {
+    public Response<Void> updateLecture(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto,
+                                        @RequestBody @Valid LectureUpdateRequestDto requestDto) {
         requestDto.setLectureCode(lectureCode);
         requestDto.setMemberDTO(memberDto);
         lectureService.updateLecture(requestDto);
@@ -45,35 +55,41 @@ public class LectureController {
     }
 
     @DeleteMapping("/lecture/{lectureCode}")
-    public Response<Void> deleteLecture(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> deleteLecture(@PathVariable String lectureCode,
+                                        @AuthenticationPrincipal MemberDto memberDto) {
         lectureService.deleteLecture(lectureCode, memberDto);
         return Response.success();
     }
 
     // 강의에 임명된 강사 조회
     @GetMapping("/lecture/{lectureCode}/teachers")
-    public Response<Page<TeacherDetailResponseDto>> readTeachers(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto, @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<TeacherDetailResponseDto>> readTeachers(@PathVariable String lectureCode,
+                                                                 @AuthenticationPrincipal MemberDto memberDto,
+                                                                 @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<TeacherDetailResponseDto> dtoList = teacherService.lookupTeachers(lectureCode, memberDto, pageable);
         return Response.success(dtoList);
     }
 
     // 강의 강사 임명
     @PostMapping("/lecture/{lectureCode}/teacher")
-    public Response<Void> appointTeacher(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto, @RequestBody @Valid AppointTeacherRequestDto requestDto) {
+    public Response<Void> appointTeacher(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto,
+                                         @RequestBody @Valid AppointTeacherRequestDto requestDto) {
         teacherService.appointTeacher(lectureCode, memberDto, requestDto);
         return Response.success();
     }
 
     // 강의 강사 해임
     @DeleteMapping("/lecture/{lectureCode}/teacher/{teacherId}")
-    public Response<Void> dismissTeacher(@PathVariable String lectureCode, @PathVariable String teacherId, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> dismissTeacher(@PathVariable String lectureCode, @PathVariable String teacherId,
+                                         @AuthenticationPrincipal MemberDto memberDto) {
         teacherService.dismissTeacher(lectureCode, teacherId, memberDto);
         return Response.success();
     }
 
     // 수강 중인 강의 조회
     @GetMapping("/lectures/taking")
-    public Response<Page<LectureDetailResponseDto>> lookupMyLectures(@AuthenticationPrincipal MemberDto memberDto, @PageableDefault(sort = "appliedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<LectureDetailResponseDto>> lookupMyLectures(@AuthenticationPrincipal MemberDto memberDto,
+                                                                     @PageableDefault(sort = "appliedAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<LectureDetailResponseDto> dtoList = studentService.lookupMyLectures(memberDto, pageable);
         return Response.success(dtoList);
     }
@@ -87,28 +103,33 @@ public class LectureController {
 
     // 수강 신청 철회
     @DeleteMapping("/lecture/{lectureCode}/application")
-    public Response<Void> cancelApplication(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> cancelApplication(@PathVariable String lectureCode,
+                                            @AuthenticationPrincipal MemberDto memberDto) {
         studentService.cancelApplication(lectureCode, memberDto);
         return Response.success();
     }
 
     // 수강 신청 인원 목록 조회
     @GetMapping("/lecture/{lectureCode}/applications")
-    public Response<Page<StudentDetailResponseDto>> readStudents(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto, @PageableDefault(sort = "appliedAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    public Response<Page<StudentDetailResponseDto>> readStudents(@PathVariable String lectureCode,
+                                                                 @AuthenticationPrincipal MemberDto memberDto,
+                                                                 @PageableDefault(sort = "appliedAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<StudentDetailResponseDto> dtoList = studentService.checkApplicants(lectureCode, memberDto, pageable);
         return Response.success(dtoList);
     }
 
     // 수강 신청 수락
     @PutMapping("/lecture/{lectureCode}/application/{applicantId}")
-    public Response<Void> acceptApplicant(@PathVariable String lectureCode, @PathVariable String applicantId, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> acceptApplicant(@PathVariable String lectureCode, @PathVariable String applicantId,
+                                          @AuthenticationPrincipal MemberDto memberDto) {
         studentService.acceptApplicant(lectureCode, applicantId, memberDto);
         return Response.success();
     }
 
     // 수강 신청 반려
     @DeleteMapping("/lecture/{lectureCode}/application/{applicantId}")
-    public Response<Void> rejectApplicant(@PathVariable String lectureCode, @PathVariable String applicantId, @AuthenticationPrincipal MemberDto memberDto) {
+    public Response<Void> rejectApplicant(@PathVariable String lectureCode, @PathVariable String applicantId,
+                                          @AuthenticationPrincipal MemberDto memberDto) {
         studentService.rejectApplicant(lectureCode, applicantId, memberDto);
         return Response.success();
     }

--- a/src/main/java/org/finalproject/tmeroom/lecture/data/dto/request/AppointTeacherRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/data/dto/request/AppointTeacherRequestDto.java
@@ -1,10 +1,15 @@
 package org.finalproject.tmeroom.lecture.data.dto.request;
 
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.CANNOT_BE_NULL;
+
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
 public class AppointTeacherRequestDto {
+
+    @NotBlank(message = CANNOT_BE_NULL)
     String teacherId;
 }

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/request/EmailConfirmRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/request/EmailConfirmRequestDto.java
@@ -1,9 +1,0 @@
-package org.finalproject.tmeroom.member.data.dto.request;
-
-import lombok.Data;
-
-@Data
-public class EmailConfirmRequestDto {
-
-    private String confirmCode;
-}

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
@@ -1,5 +1,15 @@
 package org.finalproject.tmeroom.member.data.dto.request;
 
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.CANNOT_BE_NULL;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.UNMATCHED_EMAIL;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.UNMATCHED_NICKNAME;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.UNMATCHED_PASSWORD;
+import static org.finalproject.tmeroom.common.exception.ValidationMessage.UNMATCHED_USERNAME;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Data;
 import org.finalproject.tmeroom.member.data.entity.Member;
@@ -9,9 +19,17 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @Builder
 public class MemberCreateRequestDto {
 
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Pattern(regexp = "/^[a-z0-9_]{4,15}$/", message = UNMATCHED_USERNAME)
     private String memberId;
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[A-Za-z\\d@$!%*#?&]{6,100}", message = UNMATCHED_PASSWORD)
     private String password;
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Max(value = 20, message = UNMATCHED_NICKNAME)
     private String nickname;
+    @NotBlank(message = CANNOT_BE_NULL)
+    @Email(message = UNMATCHED_EMAIL)
     private String email;
 
     public Member toEntity(PasswordEncoder encoder) {


### PR DESCRIPTION
- 스프링 내장 검증 라이브러리 Validation을 사용해, 유효하지 않은 요청에 대해 오류의 원인을 응답 메시지에 담아 보내는 기능 추가


### 버그 수정
- JwtAuthenticationFilter에서 이미 response.getWriter()를 했는데 GlobalControllerAdvice에서 예외 처리를 위해 한번 더 호출하면 런타임 오류가 일어나 INTERNAL_SERVER_ERROR 가 반환되며 요청이 처리 되지 않는 오류가 있었다.
  - 필터에서 직접 예외 메시지를 담지 않고 헤더에 예외 코드만 저장, AuthenticationEntryPoint에서 실패 메시지를 담아 보내도록 수정
