### PR TITLE
🐛	: DTO Builder 어노테이션 삭제

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/auth/data/dto/request/LoginRequestDto.java
@@ -7,7 +7,6 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-@Builder
 public class LoginRequestDto {
 
     @NotBlank(message = CANNOT_BE_NULL)

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
@@ -16,7 +16,6 @@ import org.finalproject.tmeroom.member.data.entity.Member;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Data
-@Builder
 public class MemberCreateRequestDto {
 
     @NotBlank(message = CANNOT_BE_NULL)

--- a/src/test/java/org/finalproject/TMeRoom/auth/controller/AuthControllerTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/controller/AuthControllerTest.java
@@ -1,15 +1,6 @@
 package org.finalproject.TMeRoom.auth.controller;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
 import org.finalproject.tmeroom.auth.config.SecurityConfig;
 import org.finalproject.tmeroom.auth.controller.AuthController;
 import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
@@ -29,6 +20,16 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(
         controllers = AuthController.class,
@@ -57,11 +58,9 @@ class AuthControllerTest {
             // Given
             String id = "tester00";
             String password = "test";
-            LoginRequestDto requestDto = LoginRequestDto
-                    .builder()
-                    .id(id)
-                    .pw(password)
-                    .build();
+            LoginRequestDto requestDto = new LoginRequestDto();
+            requestDto.setId(id);
+            requestDto.setPw(password);
             LoginResponseDto responseDto = LoginResponseDto.builder()
                     .accessToken("mockAccessToken")
                     .build();
@@ -90,11 +89,9 @@ class AuthControllerTest {
             // Given
             String id = "wrongId";
             String password = "password";
-            LoginRequestDto requestDto = LoginRequestDto
-                    .builder()
-                    .id(id)
-                    .pw(password)
-                    .build();
+            LoginRequestDto requestDto = new LoginRequestDto();
+            requestDto.setId(id);
+            requestDto.setPw(password);
             given(authService.login(any(LoginRequestDto.class))).willThrow(
                     new ApplicationException(ErrorCode.USER_NOT_FOUND)
             );
@@ -114,11 +111,9 @@ class AuthControllerTest {
             // Given
             String id = "tester";
             String password = "wrongPw";
-            LoginRequestDto requestDto = LoginRequestDto
-                    .builder()
-                    .id(id)
-                    .pw(password)
-                    .build();
+            LoginRequestDto requestDto = new LoginRequestDto();
+            requestDto.setId(id);
+            requestDto.setPw(password);
             given(authService.login(any(LoginRequestDto.class))).willThrow(
                     new ApplicationException(ErrorCode.INVALID_PASSWORD)
             );

--- a/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
@@ -111,10 +111,10 @@ class AuthServiceTest {
     }
 
     private LoginRequestDto getMockRequestDto() {
-        return LoginRequestDto.builder()
-                .id("tester00")
-                .pw("test")
-                .build();
+        LoginRequestDto dto = new LoginRequestDto();
+        dto.setId("tester00");
+        dto.setPw("test");
+        return dto;
     }
 
     private Member getMockMember() {

--- a/src/test/java/org/finalproject/TMeRoom/member/controller/MemberControllerTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/member/controller/MemberControllerTest.java
@@ -2,10 +2,6 @@ package org.finalproject.TMeRoom.member.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.finalproject.TMeRoom.config.TestSecurityConfig;
-import org.finalproject.tmeroom.auth.data.dto.request.LoginRequestDto;
-import org.finalproject.tmeroom.auth.data.dto.response.LoginResponseDto;
-import org.finalproject.tmeroom.common.exception.ApplicationException;
-import org.finalproject.tmeroom.common.exception.ErrorCode;
 import org.finalproject.tmeroom.member.controller.MemberController;
 import org.finalproject.tmeroom.member.data.dto.request.MemberCreateRequestDto;
 import org.finalproject.tmeroom.member.data.dto.response.MemberCreateResponseDto;
@@ -17,17 +13,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
-import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -59,13 +49,12 @@ class MemberControllerTest {
             String pw = "test";
             String email = "testerGuest@test.com";
             String nickname = "게스트";
-            MemberCreateRequestDto requestDto = MemberCreateRequestDto
-                    .builder()
-                    .memberId(id)
-                    .password(pw)
-                    .email(email)
-                    .nickname(nickname)
-                    .build();
+            MemberCreateRequestDto requestDto = new MemberCreateRequestDto();
+            requestDto.setMemberId(id);
+            requestDto.setPassword(pw);
+            requestDto.setEmail(email);
+            requestDto.setNickname(nickname);
+
             MemberCreateResponseDto responseDto = mock(MemberCreateResponseDto.class);
             given(memberService.createMember(requestDto)).willReturn(responseDto);
 

--- a/src/test/java/org/finalproject/TMeRoom/member/service/MemberServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/member/service/MemberServiceTest.java
@@ -36,11 +36,11 @@ class MemberServiceTest {
     private PasswordEncoder passwordEncoder;
 
     private MemberCreateRequestDto getMockRequestDto() {
-        return MemberCreateRequestDto.builder()
-                .email("testGuest@test.com")
-                .memberId("testGuest")
-                .password("password")
-                .build();
+        MemberCreateRequestDto dto = new MemberCreateRequestDto();
+        dto.setEmail("testGuest@test.com");
+        dto.setMemberId("testGuest");
+        dto.setPassword("password");
+        return dto;
     }
 
     private Member getMockGuestMember() {


### PR DESCRIPTION
1. 클라이언트가 Post Request 요청시에 DTO의 Builder 어노테이션으로 인해 기본 생성자가 생기지 않아 DTO가 생성되지 않는 오류가 있어 Builder 어노테이션을 삭제
2. 위와 같은 수정사항에 따른 Test Code 오류 쪽 수정