### PR TITLE
✨	: 강사 임명시 메일 전송 로직 추가

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
+++ b/src/main/java/org/finalproject/tmeroom/common/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     INVALID_LECTURE_CODE(HttpStatus.BAD_REQUEST, "존재하지 않는 강의 코드입니다."),
     INVALID_QUESTION_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 질문입니다."),
     INVALID_COMMENT_ID(HttpStatus.BAD_REQUEST, "존재하지 않는 댓글입니다."),
+    INVALID_TEACHER_ID(HttpStatus.BAD_REQUEST, "강의에 초빙되지 않은 교사입니다."),
     //    ==== 여기까지 작성 ====
     ;
 

--- a/src/main/java/org/finalproject/tmeroom/lecture/controller/LectureController.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/controller/LectureController.java
@@ -65,11 +65,27 @@ public class LectureController {
         return Response.success(dtoList);
     }
 
-    // 강의 강사 임명
+    // 강의 강사 제의
     @PostMapping("/lecture/{lectureCode}/teacher")
     public Response<Void> appointTeacher(@PathVariable String lectureCode, @AuthenticationPrincipal MemberDto memberDto,
                                          @RequestBody @Valid AppointTeacherRequestDto requestDto) {
         teacherService.appointTeacher(lectureCode, memberDto, requestDto);
+        return Response.success();
+    }
+
+    // 강사 수락
+    @PutMapping("/lecture/{lectureCode}/teacher")
+    public Response<Void> acceptTeacher(@PathVariable String lectureCode,
+                                        @AuthenticationPrincipal MemberDto memberDto) {
+        teacherService.acceptTeacher(lectureCode, memberDto);
+        return Response.success();
+    }
+
+    // 강사 거부
+    @DeleteMapping("/lecture/{lectureCode}/teacher")
+    public Response<Void> rejectTeacher(@PathVariable String lectureCode,
+                                        @AuthenticationPrincipal MemberDto memberDto) {
+        teacherService.rejectTeacher(lectureCode, memberDto);
         return Response.success();
     }
 

--- a/src/main/java/org/finalproject/tmeroom/lecture/data/dto/response/LectureCreateResponseDto.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/data/dto/response/LectureCreateResponseDto.java
@@ -15,7 +15,7 @@ public class LectureCreateResponseDto {
 
     public static LectureCreateResponseDto from(Lecture lecture) {
         return LectureCreateResponseDto.builder()
-                .lectureCode(lecture.getLectureName())
+                .lectureCode(lecture.getLectureCode())
                 .build();
     }
 }

--- a/src/main/java/org/finalproject/tmeroom/lecture/data/entity/Student.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/data/entity/Student.java
@@ -49,12 +49,11 @@ public class Student {
     private LocalDateTime acceptedAt;
 
     @Builder
-    public Student(Member member, Lecture lecture, LocalDateTime appliedAt) {
+    public Student(Member member, Lecture lecture) {
         this.studentId = member.getId();
         this.member = member;
         this.lectureCode = lecture.getLectureCode();
         this.lecture = lecture;
-        this.appliedAt = appliedAt;
     }
 
     public void acceptStudent() {

--- a/src/main/java/org/finalproject/tmeroom/lecture/data/entity/Teacher.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/data/entity/Teacher.java
@@ -8,6 +8,9 @@ import org.finalproject.tmeroom.common.data.entity.BaseTimeEntity;
 import org.finalproject.tmeroom.member.data.entity.Member;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
+import org.springframework.data.annotation.CreatedDate;
+
+import java.time.LocalDateTime;
 
 /**
  * 작성자: 김종민
@@ -39,6 +42,13 @@ public class Teacher extends BaseTimeEntity {
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Lecture lecture;
 
+    @CreatedDate
+    @Column(updatable = false, name = "suggested_at")
+    private LocalDateTime suggestedAt;
+
+    @Column(name = "accepted_at")
+    private LocalDateTime acceptedAt;
+
     @Builder
     public Teacher(Member member, Lecture lecture) {
         this.teacherId = member.getId();
@@ -46,4 +56,9 @@ public class Teacher extends BaseTimeEntity {
         this.lectureCode = lecture.getLectureCode();
         this.lecture = lecture;
     }
+
+    public void accept() {
+        this.acceptedAt = LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/org/finalproject/tmeroom/lecture/repository/TeacherRepository.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/repository/TeacherRepository.java
@@ -7,8 +7,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TeacherRepository extends JpaRepository<Teacher, TeacherPK> {
-    Teacher findByMemberIdAndLectureCode(String memberId, String lectureCode);
+    Optional<Teacher> findByMemberIdAndLectureCode(String memberId, String lectureCode);
 
     Page<Teacher> findByLecture(Pageable pageable, Lecture lecture);
 }

--- a/src/main/java/org/finalproject/tmeroom/lecture/service/StudentService.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/service/StudentService.java
@@ -18,8 +18,6 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -48,7 +46,6 @@ public class StudentService extends LectureCommon {
         Student student = Student.builder()
                 .lecture(lecture)
                 .member(registeringStudent)
-                .appliedAt(LocalDateTime.now())
                 .build();
 
         studentRepository.save(student);

--- a/src/main/java/org/finalproject/tmeroom/lecture/service/TeacherService.java
+++ b/src/main/java/org/finalproject/tmeroom/lecture/service/TeacherService.java
@@ -3,6 +3,7 @@ package org.finalproject.tmeroom.lecture.service;
 import lombok.RequiredArgsConstructor;
 import org.finalproject.tmeroom.common.exception.ApplicationException;
 import org.finalproject.tmeroom.common.exception.ErrorCode;
+import org.finalproject.tmeroom.common.service.MailService;
 import org.finalproject.tmeroom.lecture.data.dto.request.AppointTeacherRequestDto;
 import org.finalproject.tmeroom.lecture.data.dto.response.TeacherDetailResponseDto;
 import org.finalproject.tmeroom.lecture.data.entity.Lecture;
@@ -16,6 +17,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -27,6 +29,7 @@ public class TeacherService extends LectureCommon {
     private final TeacherRepository teacherRepository;
     private final MemberRepository memberRepository;
     private final LectureRepository lectureRepository;
+    private final MailService mailService;
 
     //강의 강사 조회
     public Page<TeacherDetailResponseDto> lookupTeachers(String lectureCode, MemberDto memberDto, Pageable pageable) {
@@ -40,7 +43,6 @@ public class TeacherService extends LectureCommon {
     }
 
     //강의 강사 임명
-    //TODO: 강사 임명시 바로 임명되는 로직에서 -> 이메일 수락 후 임명되는 로직으로 변경 필요
     public void appointTeacher(String lectureCode, MemberDto memberDTO, AppointTeacherRequestDto requestDTO) {
         Lecture lecture = lectureRepository.findById(lectureCode)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_LECTURE_CODE));
@@ -56,6 +58,21 @@ public class TeacherService extends LectureCommon {
                 .build();
 
         teacherRepository.save(teacher);
+        sendConfirmMail(lecture.getLectureName(), lecture.getLectureCode(), MemberDto.from(appointedMember));
+    }
+
+    public void acceptTeacher(String lectureCode, MemberDto memberDTO) {
+        Teacher suggestedTeacher = teacherRepository.findByMemberIdAndLectureCode(memberDTO.getId(), lectureCode)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_TEACHER_ID));
+
+        suggestedTeacher.accept();
+    }
+
+    public void rejectTeacher(String lectureCode, MemberDto memberDTO) {
+        Teacher suggestedTeacher = teacherRepository.findByMemberIdAndLectureCode(memberDTO.getId(), lectureCode)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_TEACHER_ID));
+
+        teacherRepository.delete(suggestedTeacher);
     }
 
     //강의 강사 해임
@@ -64,8 +81,35 @@ public class TeacherService extends LectureCommon {
                 .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_LECTURE_CODE));
         checkPermission(lecture, memberDTO);
 
-        Teacher dismissedTeacher = teacherRepository.findByMemberIdAndLectureCode(teacherId, lectureCode);
+        Teacher dismissedTeacher = teacherRepository.findByMemberIdAndLectureCode(teacherId, lectureCode)
+                .orElseThrow(() -> new ApplicationException(ErrorCode.INVALID_TEACHER_ID));
 
         teacherRepository.delete(dismissedTeacher);
     }
+
+    //강사 확인 메일
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendConfirmMail(String lectureName, String lectureCode, MemberDto memberDto) {
+        String subject = "[티미룸]" + lectureName + "에 강사로 제의되었습니다.";
+        String content = getConfirmMailContent(lectureCode);
+        mailService.sendEmail(memberDto.getEmail(), subject, content, true, false);
+    }
+
+    // TODO: 요청을 백엔드로 직접 보내도록 했는데, 프론트가 짜여지면 링크를 수정해야 함.
+    private String getConfirmMailContent(String confirmCode) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<div style='margin:20px;'>");
+        sb.append("<p>티미룸 강사 제의 수락하시겠습니까?</p>");
+        sb.append("<br>");
+        sb.append("<div align='center' style='border:1px solid black; font-family:verdana'>");
+        sb.append("<h3>수락 / 거부</h3>");
+        sb.append("<div style='font-size:130%'>");
+        sb.append("<strong>localhost:8080/api/v1/email/member/confirm/" + confirmCode + "</strong></div><br/>");
+        sb.append("<strong>localhost:8080/api/v1/email/member/confirm/" + confirmCode + "</strong></div><br/>");
+        sb.append("</div></br></br>");
+        sb.append("<p>감사합니다.</p>");
+        sb.append("</div>");
+        return sb.toString();
+    }
+
 }

--- a/src/test/java/org/finalproject/TMeRoom/lecture/service/StudentServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/lecture/service/StudentServiceTest.java
@@ -165,7 +165,6 @@ class StudentServiceTest {
             Student studentEntity = Student.builder()
                     .member(mockStudent)
                     .lecture(mockLecture)
-                    .appliedAt(LocalDateTime.now())
                     .build();
 
 

--- a/src/test/java/org/finalproject/TMeRoom/lecture/service/TeacherServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/lecture/service/TeacherServiceTest.java
@@ -213,8 +213,8 @@ class TeacherServiceTest {
             Teacher teacher = getMockTeacher();
 
             given(lectureRepository.findById(lectureCode)).willReturn(Optional.of(lecture));
-            given(teacherRepository.findByMemberIdAndLectureCode(teacher.getTeacherId(), lectureCode)).willReturn(
-                    teacher);
+            given(teacherRepository.findByMemberIdAndLectureCode(teacher.getTeacherId(), lectureCode))
+                    .willReturn(Optional.of(teacher));
 
             //When
             teacherService.dismissTeacher(lectureCode, teacher.getTeacherId(), mockManagerDto);
@@ -233,8 +233,8 @@ class TeacherServiceTest {
             Teacher teacher = getMockTeacher();
 
             given(lectureRepository.findById(lectureCode)).willReturn(Optional.of(lecture));
-            given(teacherRepository.findByMemberIdAndLectureCode(teacher.getTeacherId(), lectureCode)).willReturn(
-                    teacher);
+            given(teacherRepository.findByMemberIdAndLectureCode(teacher.getTeacherId(), lectureCode))
+                    .willReturn(Optional.of(teacher));
 
             //When
             Throwable throwable = catchThrowable(


### PR DESCRIPTION
기존에 관리자가 강사를 임명할 때 바로 등록되는 로직에서 강사에게 메일을 보내어 수락을 하였을 때 강사에 임명되도록 로직으로 변경