### PR TITLE
⏪	: Member 엔티티에서 PasswordEncoder 참조하지 않도록 변경

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/common/config/EmailConfig.java
+++ b/src/main/java/org/finalproject/tmeroom/common/config/EmailConfig.java
@@ -2,18 +2,59 @@ package org.finalproject.tmeroom.common.config;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+import java.util.Properties;
 import java.util.concurrent.Executor;
 
 @Slf4j
 @Configuration
 @EnableAsync
 public class EmailConfig implements AsyncConfigurer {
+
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+    @Value("${spring.mail.username}")
+    private String username;
+    @Value("${spring.mail.password}")
+    private String password;
+    @Value("${spring.mail.transport.protocol}")
+    private String protocol;
+    @Value("${spring.mail.properties.mail.smtp.auth}")
+    private boolean auth;
+    @Value("${spring.mail.properties.mail.smtp.starttls.enable}")
+    private boolean starttls;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host);
+        javaMailSender.setPort(port);
+        javaMailSender.setUsername(username);
+        javaMailSender.setPassword(password);
+        javaMailSender.setDefaultEncoding("UTF-8");
+        javaMailSender.setJavaMailProperties(getMailProperties());
+
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.put("mail.transport.protocol", protocol);
+        properties.put("mail.smtp.auth", auth);
+        properties.put("mail.smtp.starttls.enable", starttls);
+        return properties;
+    }
 
     @Override
     @Bean(name = "mailAsync")

--- a/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/dto/request/MemberCreateRequestDto.java
@@ -26,13 +26,12 @@ public class MemberCreateRequestDto {
     @Email(message = UNMATCHED_EMAIL)
     private String email;
 
-    public Member toEntity(PasswordEncoder encoder) {
+    public Member toEntity() {
         return Member.builder()
                 .id(memberId)
                 .pw(password)
                 .nickname(nickname)
                 .email(email)
-                .encoder(encoder)
                 .build();
     }
 

--- a/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
+++ b/src/main/java/org/finalproject/tmeroom/member/data/entity/Member.java
@@ -46,9 +46,9 @@ public class Member extends BaseTimeEntity {
     private MemberRole role;
 
     @Builder
-    public Member(String id, String pw, String nickname, String email, MemberRole role, PasswordEncoder encoder) {
+    public Member(String id, String pw, String nickname, String email, MemberRole role) {
         this.id = id;
-        this.pw = encoder.encode(pw);
+        this.pw = pw;
         this.nickname = nickname;
         this.email = email;
         this.role = role == null ? MemberRole.GUEST : role;
@@ -62,15 +62,11 @@ public class Member extends BaseTimeEntity {
     }
 
     public boolean isIdMatch(String id) {
-        return id.equals(this.id);
+        return this.id.equals(id);
     }
 
-    public boolean isPasswordMatch(PasswordEncoder encoder, String pw) {
-        return encoder.matches(pw, this.pw);
-    }
-
-    public void updatePassword(PasswordEncoder encoder, String pw) {
-        this.pw = encoder.encode(pw);
+    public void updatePassword(String pw) {
+        this.pw = pw;
     }
 
     public void updateInfo(MemberUpdateRequestDto requestDto) {

--- a/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
+++ b/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
@@ -47,7 +47,7 @@ public class MemberService {
             throw new ApplicationException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        Member savedMember = memberRepository.save(requestDto.toEntity(passwordEncoder));
+        Member savedMember = memberRepository.save(requestDto.toEntity());
         sendConfirmMail(MemberDto.from(savedMember));
         return MemberCreateResponseDto.from(savedMember);
     }
@@ -99,11 +99,11 @@ public class MemberService {
         Member foundMember = memberRepository.findById(memberDto.getId())
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
-        if (!foundMember.isPasswordMatch(passwordEncoder, requestDto.getOldPassword())) {
+        if (!passwordEncoder.matches(foundMember.getPw(), requestDto.getOldPassword())) {
             throw new ApplicationException(ErrorCode.INVALID_PASSWORD);
         }
 
-        foundMember.updatePassword(passwordEncoder, requestDto.getNewPassword());
+        foundMember.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
     }
 
     public void deleteMember(MemberDto memberDto) {
@@ -149,7 +149,7 @@ public class MemberService {
         Member foundMember = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.USER_NOT_FOUND));
 
-        foundMember.updatePassword(passwordEncoder, requestDto.getNewPassword());
+        foundMember.updatePassword(passwordEncoder.encode(requestDto.getNewPassword()));
 
         passwordResetCodeRepository.deleteByCode(requestDto.getResetCode());
     }

--- a/src/main/resources/config/mail/application.yml
+++ b/src/main/resources/config/mail/application.yml
@@ -1,9 +1,40 @@
 spring:
+  config:
+    activate:
+      on-profile:
+        - test
+
+  mail:
+    host: localhost
+    port: 3025
+    username: tester@test.com
+    password: tester
+    transport:
+      protocol: smtp
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile:
+        - local
+        - dev
+        - prod
+
   mail:
     host: smtp.gmail.com
     port: 587
     username: ${GMAIL_ADDRESS}
     password: ${GMAIL_PASSWORD}
+    transport:
+      protocol: smtp
     properties:
       mail:
         smtp:

--- a/src/test/java/org/finalproject/TMeRoom/TMeRoomApplicationTests.java
+++ b/src/test/java/org/finalproject/TMeRoom/TMeRoomApplicationTests.java
@@ -1,11 +1,21 @@
 package org.finalproject.TMeRoom;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@SpringBootTest
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(
+        properties = {
+                "spring.config.additional-location=classpath:config/*/",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration",
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration"
+        }
+)
 @TestPropertySource(properties = {
         "JWT_KEY=LongLongLongLongLongLongLongLongTestJWTKey"
 })

--- a/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
+++ b/src/test/java/org/finalproject/TMeRoom/auth/service/AuthServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.finalproject.TMeRoom.common.util.MockMemberProvider.getMockUserMember;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -47,18 +48,6 @@ class AuthServiceTest {
         return dto;
     }
 
-    private Member getMockMember() {
-        given(passwordEncoder.encode(any(String.class))).willReturn("encodedPw");
-        return Member.builder()
-                .id("tester00")
-                .pw("password")
-                .email("tester@test.com")
-                .nickname("tester")
-                .role(MemberRole.USER)
-                .encoder(passwordEncoder)
-                .build();
-    }
-
     @Nested
     @DisplayName("로그인 기능 테스트")
     class aboutLogin {
@@ -68,7 +57,7 @@ class AuthServiceTest {
         void givenProperRequestDto_whenLoggingIn_thenReturnsToken() {
             // Given
             LoginRequestDto mockRequestDto = getMockRequestDto();
-            Member mockMember = getMockMember();
+            Member mockMember = getMockUserMember();
             String mockAccessToken = "mockAccessToken";
             given(memberRepository.findById(mockRequestDto.getId())).willReturn(Optional.of(mockMember));
             given(passwordEncoder.matches(mockRequestDto.getPw(), mockMember.getPw())).willReturn(true);
@@ -107,7 +96,7 @@ class AuthServiceTest {
         void givenWrongPassword_whenLoggingIn_thenThrowsUserNotFoundException() {
             // Given
             LoginRequestDto mockRequestDto = getMockRequestDto();
-            Member mockMember = getMockMember();
+            Member mockMember = getMockUserMember();
             given(memberRepository.findById(mockRequestDto.getId())).willReturn(Optional.of(mockMember));
             given(passwordEncoder.matches(mockRequestDto.getPw(), mockMember.getPw())).willReturn(false);
 

--- a/src/test/java/org/finalproject/TMeRoom/common/config/TestSecurityConfig.java
+++ b/src/test/java/org/finalproject/TMeRoom/common/config/TestSecurityConfig.java
@@ -22,4 +22,7 @@ import org.springframework.security.web.FilterChainProxy;
 @Import({SecurityConfig.class, JwtTokenProvider.class, TokenAuthenticationService.class,
         CustomAccessDeniedHandler.class, CustomAuthenticationEntryPoint.class})
 public class TestSecurityConfig {
+
+    @MockBean
+    private MemberRepository memberRepository;
 }

--- a/src/test/java/org/finalproject/TMeRoom/common/util/MockMemberProvider.java
+++ b/src/test/java/org/finalproject/TMeRoom/common/util/MockMemberProvider.java
@@ -1,28 +1,11 @@
 package org.finalproject.TMeRoom.common.util;
 
-import jakarta.annotation.PostConstruct;
 import org.finalproject.tmeroom.member.constant.MemberRole;
 import org.finalproject.tmeroom.member.data.entity.Member;
 import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.crypto.password.PasswordEncoder;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
 
 @TestConfiguration
 public class MockMemberProvider {
-
-    @MockBean
-    private PasswordEncoder encoderBean;
-
-    private static PasswordEncoder passwordEncoder;
-
-    @PostConstruct
-    private void init() {
-        given(encoderBean.encode(any(String.class))).willReturn("encodedPassword");
-        passwordEncoder = encoderBean;
-    }
 
     public static Member getMockGuestMember() {
         return Member.builder()
@@ -31,7 +14,6 @@ public class MockMemberProvider {
                 .email("testGuest@test.com")
                 .nickname("testGuest")
                 .role(MemberRole.GUEST)
-                .encoder(passwordEncoder)
                 .build();
     }
 
@@ -42,7 +24,6 @@ public class MockMemberProvider {
                 .email("testUser@test.com")
                 .nickname("testUser")
                 .role(MemberRole.USER)
-                .encoder(passwordEncoder)
                 .build();
     }
 
@@ -53,7 +34,6 @@ public class MockMemberProvider {
                 .email("testManager@test.com")
                 .nickname("manager")
                 .role(MemberRole.USER)
-                .encoder(passwordEncoder)
                 .build();
     }
 
@@ -64,7 +44,6 @@ public class MockMemberProvider {
                 .email("testStudent@test.com")
                 .nickname("student")
                 .role(MemberRole.USER)
-                .encoder(passwordEncoder)
                 .build();
     }
 
@@ -75,7 +54,6 @@ public class MockMemberProvider {
                 .email("testGuest@test.com")
                 .nickname("teacher")
                 .role(MemberRole.USER)
-                .encoder(passwordEncoder)
                 .build();
     }
 
@@ -86,7 +64,6 @@ public class MockMemberProvider {
                 .email("testGuest@test.com")
                 .nickname("anonymous")
                 .role(MemberRole.USER)
-                .encoder(passwordEncoder)
                 .build();
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,9 +1,0 @@
-jwt:
-  secret:
-    key: LongLongLongLongLongLongLongLongTestJWTKey
-
-spring:
-  data:
-    redis:
-      host: localhost
-      port: 6379


### PR DESCRIPTION
- 다음과 같은 이유로 MemberEntity 에서 PasswordEncoder 의존성을 제거했습니다.
  - 엔티티는 데이터의 표현과 저장의 책임을 가지고, 보안 작업의 책임을 가지지는 않음
  - 엔티티에서 빈을 주입받으면 엔티티의 생명 주기와 빈의 생명 주기가 얽혀 엔티티가 메모리에 남아있을 수 있음
  - 테스트 시에 목을 위한 엔티티를 만들기 위해 빈을 주입시켜주어야 해, 테스트가 복잡해짐
