### PR TITLE
🚑	: PR #38에서 리팩토링하며 비밀번호 인코딩 로직을 빼먹은 점 수정

### DIFF
--- a/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
+++ b/src/main/java/org/finalproject/tmeroom/member/service/MemberService.java
@@ -47,7 +47,10 @@ public class MemberService {
             throw new ApplicationException(ErrorCode.DUPLICATE_EMAIL);
         }
 
-        Member savedMember = memberRepository.save(requestDto.toEntity());
+        Member newMember = requestDto.toEntity();
+        newMember.updatePassword(passwordEncoder.encode(requestDto.getPassword()));
+
+        Member savedMember = memberRepository.save(newMember);
         sendConfirmMail(MemberDto.from(savedMember));
         return MemberCreateResponseDto.from(savedMember);
     }


### PR DESCRIPTION
#38 에서 회원 엔티티에서 PasswordEncoder 빈에 대한 의존성을 제거하면서, 실수로 회원가입 로직에는 비밀번호를 인코딩하는 로직을 옮겨 넣지 않았습니다.

이번 긴급수정 PR을 통해 이를 수정했습니다.